### PR TITLE
Use blue outline style for all buttons

### DIFF
--- a/web/index_v4.html
+++ b/web/index_v4.html
@@ -11,8 +11,8 @@
       --surface: #141922;
       --muted: #94a3b8;
       --text: #e6eef8;
-      --accent: #6ee7b7; /* teal/green for hope */
-      --accent-strong: #34d399;
+      --accent: #007bff;
+      --accent-strong: #007bff;
       --card: #1b2330;
       --card-border: #263043;
       --warning: #fbbf24;
@@ -37,8 +37,8 @@
       margin: 0;
       font: 16px/1.5 ui-sans-serif, -apple-system, Segoe UI, Roboto, Helvetica, Arial, "Apple Color Emoji", "Segoe UI Emoji";
       color: var(--text);
-      background: radial-gradient(1200px 600px at 70% -10%, rgba(52, 211, 153, 0.15), transparent 60%),
-                  radial-gradient(800px 400px at 0% 0%, rgba(99, 102, 241, 0.12), transparent 60%),
+        background: radial-gradient(1200px 600px at 70% -10%, rgba(0, 123, 255, 0.15), transparent 60%),
+                    radial-gradient(800px 400px at 0% 0%, rgba(0, 123, 255, 0.12), transparent 60%),
                   var(--bg);
     }
     .container { width: min(1120px, 92%); margin: 0 auto; }
@@ -56,10 +56,10 @@
     nav[aria-label="Primary"] a { text-decoration: none; color: var(--text); opacity: .88; padding: .5rem .7rem; border-radius: .5rem; }
     nav[aria-label="Primary"] a:hover { background: color-mix(in lab, var(--card), transparent 40%); opacity: 1; }
 
-    .btn { display: inline-flex; align-items: center; justify-content: center; gap: .5rem; padding: .8rem 1.1rem; border-radius: .8rem; border: 1px solid var(--card-border); background: var(--surface); color: var(--text); text-decoration: none; font-weight: 650; box-shadow: var(--shadow); }
-    .btn:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus), var(--shadow); }
-    .btn-primary { background: linear-gradient(135deg, var(--accent), var(--accent-strong)); color: #0b1320; border-color: transparent; }
-    .btn-outline { background: transparent; border-color: var(--card-border); }
+      .btn { display: inline-flex; align-items: center; justify-content: center; gap: .5rem; padding: .8rem 1.1rem; border-radius: 999px; border: 2px solid var(--accent); background: #fff; color: var(--accent); text-decoration: none; font-weight: 650; box-shadow: var(--shadow); }
+      .btn:focus-visible { outline: none; box-shadow: 0 0 0 3px var(--focus), var(--shadow); }
+      .btn-primary { background: #fff; color: var(--accent); border-color: var(--accent); }
+      .btn-outline { background: #fff; border-color: var(--accent); }
 
     /* Global card default */
     .card { background: var(--card); border: 1px solid var(--card-border); border-radius: 1rem; padding: 1rem; }
@@ -96,8 +96,8 @@
     blockquote { margin: 0; font-size: 1.05rem; }
     .quote { color: var(--muted); }
     .cite { display: block; margin-top: .5rem; font-weight: 700; }
-    .carousel__control { position: absolute; top: 50%; transform: translateY(-50%); border: 1px solid var(--card-border); background: var(--surface); color: var(--text); width: 40px; height: 40px; border-radius: 999px; display: grid; place-items: center; cursor: pointer; }
-    .carousel__control:hover { background: color-mix(in lab, var(--surface), transparent 20%); }
+      .carousel__control { position: absolute; top: 50%; transform: translateY(-50%); border: 2px solid var(--accent); background: #fff; color: var(--accent); width: 40px; height: 40px; border-radius: 999px; display: grid; place-items: center; cursor: pointer; }
+      .carousel__control:hover { background: color-mix(in srgb, var(--accent), #fff 90%); }
     .carousel__control.prev { left: .6rem; }
     .carousel__control.next { right: .6rem; }
     .dots { display: flex; gap: .4rem; justify-content: center; margin-top: .6rem; }

--- a/web/style.css
+++ b/web/style.css
@@ -24,9 +24,9 @@
     .intake{display:grid; gap:1rem}
     .row{display:flex; gap:.5rem; flex-wrap:wrap; justify-content:center}
     .label{font-weight:800}
-    .chip{padding:.55rem .9rem; border-radius:999px; border:1px solid var(--accent); background:var(--accent); color:#fff; cursor:pointer}
-    .chip[aria-pressed="true"], .pill[aria-pressed="true"]{border-color:var(--accent); background:var(--accent); color:#fff}
-    .pill{display:inline-flex; align-items:center; gap:.5rem; padding:.7rem 1rem; border-radius:999px; border:1px solid var(--accent); cursor:pointer; background:var(--accent); color:#fff}
+    .chip{padding:.55rem .9rem; border-radius:999px; border:2px solid var(--accent); background:#fff; color:var(--accent); cursor:pointer}
+    .chip[aria-pressed="true"], .pill[aria-pressed="true"]{border-color:var(--accent); background:#fff; color:var(--accent)}
+    .pill{display:inline-flex; align-items:center; gap:.5rem; padding:.7rem 1rem; border-radius:999px; border:2px solid var(--accent); cursor:pointer; background:#fff; color:var(--accent)}
     .today{display:grid; gap:.8rem}
 
     footer{margin-top:2rem; text-align:center; font-size:12pt; color:#666}
@@ -34,25 +34,25 @@
     /* Phase chip as button with caret */
     .phase{
       display:inline-flex; align-items:center; gap:.5rem; padding:.35rem .7rem;
-      border-radius:999px; border:1px solid var(--accent);
-      background:var(--accent); color:#fff; font-weight:800;
+      border-radius:999px; border:2px solid var(--accent);
+      background:#fff; color:var(--accent); font-weight:800;
       cursor:pointer;
     }
-    .phase:after{ content:"▾"; font-weight:900; color:#fff; margin-left:.2rem; }
+    .phase:after{ content:"▾"; font-weight:900; color:var(--accent); margin-left:.2rem; }
 
     .todo{display:grid; gap:.4rem}
     details.more{border-top:1px dashed var(--border); padding-top:.6rem}
 
     /* Buttons — readable in dark & light */
     .btn{
-      appearance:none; border:1px solid var(--accent); background:var(--accent); color:#fff;
-      border-radius:.8rem; padding:.8rem 1.1rem; font-weight:700; letter-spacing:.01em; cursor:pointer;
+      appearance:none; border:2px solid var(--accent); background:#fff; color:var(--accent);
+      border-radius:999px; padding:.8rem 1.1rem; font-weight:700; letter-spacing:.01em; cursor:pointer;
       transition:background .15s ease, opacity .15s ease;
     }
     .btn:hover{opacity:.98}
     .btn:focus-visible{outline:none; box-shadow:0 0 0 3px var(--focus), var(--shadow)}
-    .btn.primary{background:var(--accent); color:#fff; border-color:var(--accent)}
-    .btn.ghost{background:var(--accent); color:#fff; border-color:var(--accent); opacity:1}
+    .btn.primary{background:#fff; color:var(--accent); border-color:var(--accent)}
+    .btn.ghost{background:#fff; color:var(--accent); border-color:var(--accent); opacity:1}
 
     /* Coach panel */
     .coach-fab{position:fixed; right:20px; bottom:20px; z-index:90;} /* below coach panel */
@@ -71,9 +71,9 @@
     .coach-pager{display:flex; justify-content:space-between; gap:.6rem; padding-top:.6rem}
 
     /* Active tool style */
-    .coach-tools .btn{ background:var(--accent); color:#fff; border-color:var(--accent); }
+    .coach-tools .btn{ background:#fff; color:var(--accent); border-color:var(--accent); }
     .coach-tools .btn.active, .coach-tools .btn[aria-pressed="true"]{
-      background:var(--accent); color:#fff; border-color:var(--accent);
+      background:#fff; color:var(--accent); border-color:var(--accent);
     }
 
     .coach-footer{position:sticky; bottom:0; background:var(--surface); display:flex; gap:.5rem; padding:.6rem 1rem 1rem; border-top:1px solid var(--border)}


### PR DESCRIPTION
## Summary
- Restyle app buttons, chips, and phase selectors with a 2px blue outline, blue text, and white fill
- Align the v4 page to the same blue accent and outlined button style

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a87a7b45b48332afda46b13bbaa8a4