### PR TITLE
Style active buttons with black background and text

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -127,8 +127,29 @@
     }
 
     /* Primary button style: blue background with white border and text */
-    .btn-primary{
-      background:var(--accent) !important;
-      border:1px solid #fff !important;
-      color:#fff !important;
+.btn-primary{
+  background:var(--accent) !important;
+  border:1px solid #fff !important;
+  color:#fff !important;
+}
+
+    /* Active button style: black background and black text */
+    button:active,
+    .btn:active,
+    .chip:active,
+    .pill:active,
+    .phase:active,
+    button.active,
+    .btn.active,
+    .chip.active,
+    .pill.active,
+    .phase.active,
+    button[aria-pressed="true"],
+    .btn[aria-pressed="true"],
+    .chip[aria-pressed="true"],
+    .pill[aria-pressed="true"],
+    .phase[aria-pressed="true"] {
+      background:#000 !important;
+      border:1px solid #000 !important;
+      color:#000 !important;
     }


### PR DESCRIPTION
## Summary
- style all button types to show black background, text, and border when active or pressed

## Testing
- `python -m py_compile app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a89e6618bc83328905058e9dca3307