### PR TITLE
fix: show white text for active buttons

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -133,7 +133,7 @@
   color:#fff !important;
 }
 
-    /* Active button style: black background and black text */
+    /* Active button style: black background and white text */
     button:active,
     .btn:active,
     .chip:active,
@@ -151,5 +151,5 @@
     .phase[aria-pressed="true"] {
       background:#000 !important;
       border:1px solid #000 !important;
-      color:#000 !important;
+      color:#fff !important;
     }


### PR DESCRIPTION
## Summary
- use white text for active buttons to contrast black background

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a89ffee2208332aa545013abd0b3f5