### PR TITLE
Fix mobile tool drawer scrolling

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -85,7 +85,7 @@
     .msg-coach{background:transparent; border:1px dashed var(--border)}
 
     /* Library drawer */
-    .drawer{position:fixed; left:0; bottom:0; right:0; transform:translateY(100%); transition:.25s ease; background:var(--surface); border-top:1px solid var(--border); box-shadow:var(--shadow); z-index:100}
+    .drawer{position:fixed; left:0; bottom:0; right:0; top:0; transform:translateY(100%); transition:.25s ease; background:var(--surface); border-top:1px solid var(--border); box-shadow:var(--shadow); z-index:100; overflow-y:auto;}
     .drawer.open{transform:translateY(0)}
     .drawer .grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.6rem; padding:1rem}
     @media (max-width:720px){ .drawer .grid{grid-template-columns:1fr} }


### PR DESCRIPTION
## Summary
- allow scrolling to the top of the Tools drawer on mobile by making it fill the screen and scroll

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a968ec62d88332a656ac0066a05ad9