### PR TITLE
Add tool subpages and link drawer

### DIFF
--- a/web/cv.html
+++ b/web/cv.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>CV & LinkedIn Lab</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <div class="wrap">
+    <h1>CV & LinkedIn Lab</h1>
+    <p class="muted">Coming soon.</p>
+  </div>
+</body>
+</html>

--- a/web/financial.html
+++ b/web/financial.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Financial Checklist</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <div class="wrap">
+    <h1>Financial Checklist</h1>
+    <p class="muted">Coming soon.</p>
+  </div>
+</body>
+</html>

--- a/web/index.html
+++ b/web/index.html
@@ -152,22 +152,22 @@
       <article class="card panel">
         <h3>CV & LinkedIn Lab</h3>
         <p class="muted">Evidence-led improvements, fast.</p>
-        <button class="btn">Open</button>
+        <a class="btn" href="cv.html">Open</a>
       </article>
       <article class="card panel">
         <h3>Application Tracker</h3>
         <p class="muted">Keep momentum with follow-ups.</p>
-        <button class="btn">Open</button>
+        <a class="btn" href="tracker.html">Open</a>
       </article>
       <article class="card panel">
         <h3>Interview Simulator</h3>
         <p class="muted">Practice senior-level prompts.</p>
-        <button class="btn">Start</button>
+        <a class="btn" href="interview.html">Start</a>
       </article>
       <article class="card panel">
         <h3>Financial Checklist</h3>
         <p class="muted">ALV, health, pension — step-by-step.</p>
-        <button class="btn">Download</button>
+        <a class="btn" href="financial.html">Download</a>
       </article>
     </div>
   </div>
@@ -543,6 +543,10 @@
     const closeLib = document.getElementById('close-drawer');
     openLib.onclick = ()=>{ drawer.classList.add('open'); openLib.setAttribute('aria-expanded','true'); };
     closeLib.onclick = ()=>{ drawer.classList.remove('open'); openLib.setAttribute('aria-expanded','false'); };
+    if (location.hash === '#tools') {
+      drawer.classList.add('open');
+      openLib.setAttribute('aria-expanded','true');
+    }
 
     // ---------- API calls ----------
     async function callCoach(kind, state, note){

--- a/web/interview.html
+++ b/web/interview.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Interview Simulator</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <div class="wrap">
+    <h1>Interview Simulator</h1>
+    <p class="muted">Coming soon.</p>
+  </div>
+</body>
+</html>

--- a/web/tracker.html
+++ b/web/tracker.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <title>Application Tracker</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <div class="wrap">
+    <h1>Application Tracker</h1>
+    <p class="muted">Coming soon.</p>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add dedicated subpages for CV & LinkedIn Lab, Application Tracker, Interview Simulator, and Financial Checklist.
- Link tool drawer buttons to their respective pages and open drawer automatically when returning with `#tools`.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a984473bb48332a3445ef1e6d2e8ce