### PR TITLE
Remove underline from hyperlink-styled buttons

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -54,6 +54,7 @@
     .btn:focus-visible{outline:none; box-shadow:0 0 0 3px var(--focus), var(--shadow)}
     .btn.primary{background:#fff; color:var(--accent); border-color:var(--accent)}
     .btn.ghost{background:#fff; color:var(--accent); border-color:var(--accent); opacity:1}
+    a.btn{text-decoration:none}
 
     /* Coach panel */
     .coach-fab{position:fixed; right:20px; bottom:20px; z-index:90;} /* below coach panel */


### PR DESCRIPTION
## Summary
- prevent underlines on buttons rendered as hyperlinks

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a998cef2d48332a42815e2d9648531