### PR TITLE
Style subpage back buttons like Tools drawer close

### DIFF
--- a/web/cv.html
+++ b/web/cv.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>CV & LinkedIn Lab</h1>
     <p class="muted">Coming soon.</p>

--- a/web/financial.html
+++ b/web/financial.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Financial Checklist</h1>
     <p class="muted">Coming soon.</p>

--- a/web/interview.html
+++ b/web/interview.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Interview Simulator</h1>
     <p class="muted">Coming soon.</p>

--- a/web/style.css
+++ b/web/style.css
@@ -117,6 +117,9 @@
     }
     .phase-actions{display:flex; gap:.5rem; justify-content:flex-end; margin-top:.3rem}
 
+    /* Back button on tool pages */
+    .back-btn{position:fixed; top:1rem; right:1rem}
+
     /* Override all buttons to 1px black border, black text and white background */
     button,
     .btn,

--- a/web/tracker.html
+++ b/web/tracker.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <a href="index.html#tools" class="btn ghost" style="position:fixed; top:1rem; right:1rem;">Back</a>
+  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Application Tracker</h1>
     <p class="muted">Coming soon.</p>


### PR DESCRIPTION
## Summary
- Replace subpage Back links with buttons using `btn ghost` styling for consistency with the Tools drawer's Close control
- Add reusable `.back-btn` class in CSS for fixed top-right placement

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a99ba060508332940170acdc25ef42