### PR TITLE
Convert welcome CTAs to image tiles

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -24,10 +24,10 @@
       <div class="card panel center">
         <h1>We got you! Step by step you'll get there.</h1>
         <p class="muted">I’ll ask one or two things, then show just your next step.</p>
-        <div class="choices">
-          <button class="pill btn-primary" data-choice="lost">I just lost my job</button>
-          <button class="pill btn-primary" data-choice="explore">I’m exploring a change</button>
-          <button class="pill btn-primary" data-choice="stuck">I’m stuck / stressed</button>
+        <div class="choices tiles">
+          <button class="tile" data-choice="lost" style="--bg:url('https://images.unsplash.com/photo-1507679799987-c73779587ccf?auto=format&fit=crop&w=600&q=80');">I just lost my job</button>
+          <button class="tile" data-choice="explore" style="--bg:url('https://images.unsplash.com/photo-1504384308090-c894fdcc538d?auto=format&fit=crop&w=600&q=80');">I’m exploring a change</button>
+          <button class="tile" data-choice="stuck" style="--bg:url('https://images.unsplash.com/photo-1526662092594-e98c1e356d6d?auto=format&fit=crop&w=600&q=80');">I’m stuck / stressed</button>
         </div>
         <button id="skip-intake" class="btn">Skip — just give me a plan</button>
       </div>
@@ -238,7 +238,7 @@
     });
 
     // Welcome → Intake / Skip
-    document.querySelectorAll('#scr-welcome .pill').forEach(btn=>{
+    document.querySelectorAll('#scr-welcome .tile').forEach(btn=>{
       btn.addEventListener('click', ()=>{ show(scrIntake); });
     });
     document.getElementById('skip-intake').addEventListener('click', ()=>{

--- a/web/style.css
+++ b/web/style.css
@@ -158,3 +158,28 @@
       border:1px solid #000 !important;
       color:#fff !important;
     }
+
+    /* Tile-style call to actions on welcome screen */
+    .choices.tiles{
+      display:grid;
+      gap:.6rem;
+      grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+    }
+
+    button.tile{
+      position:relative;
+      display:flex;
+      align-items:flex-end;
+      justify-content:center;
+      height:140px;
+      padding:1rem;
+      border-radius:1rem;
+      cursor:pointer;
+      background-image:var(--bg) !important;
+      background-size:cover !important;
+      background-position:center !important;
+      color:#fff !important;
+      border:1px solid #000 !important;
+      text-shadow:0 1px 2px rgba(0,0,0,.6);
+      font-weight:700;
+    }


### PR DESCRIPTION
## Summary
- Replace welcome screen pill buttons with image-backed tiles for lost job, exploring change and feeling stuck
- Style new tiles with grid layout and background image support
- Update JS to bind tile clicks to intake screen

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9a34c873c83329abcb79c79c6865f