### PR TITLE
Use browser history for Tools back buttons

### DIFF
--- a/web/cv.html
+++ b/web/cv.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>CV & LinkedIn Lab</h1>
     <p class="muted">Coming soon.</p>

--- a/web/financial.html
+++ b/web/financial.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Financial Checklist</h1>
     <p class="muted">Coming soon.</p>

--- a/web/interview.html
+++ b/web/interview.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Interview Simulator</h1>
     <p class="muted">Coming soon.</p>

--- a/web/tracker.html
+++ b/web/tracker.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css">
 </head>
 <body>
-  <button onclick="location.href='index.html#tools'" class="btn ghost back-btn">Back</button>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Application Tracker</h1>
     <p class="muted">Coming soon.</p>


### PR DESCRIPTION
## Summary
- Allow CV, Financial, Interview, and Tracker tool pages to navigate back using the browser history instead of a fixed URL.

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9a3f76d748332b616b28eecb61df1