### PR TITLE
Responsive layout for entry tiles

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -163,7 +163,11 @@
     .choices.tiles{
       display:grid;
       gap:.6rem;
-      grid-template-columns:repeat(auto-fit,minmax(150px,1fr));
+      grid-template-columns:1fr;
+    }
+
+    @media (min-width:600px){
+      .choices.tiles{grid-template-columns:repeat(3,1fr);}
     }
 
     button.tile{


### PR DESCRIPTION
## Summary
- make welcome screen tiles stack vertically on narrow viewports and form three columns on wider screens

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9bb5c9b4083329216662cb398951b