### PR TITLE
Adjust tile aspect ratio and remove borders

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -166,16 +166,13 @@
       grid-template-columns:1fr;
     }
 
-    @media (min-width:600px){
-      .choices.tiles{grid-template-columns:repeat(3,1fr);}
-    }
-
     button.tile{
       position:relative;
       display:flex;
       align-items:flex-end;
       justify-content:center;
-      height:140px;
+      width:100%;
+      aspect-ratio: 2 / 1;
       padding:1rem;
       border-radius:1rem;
       cursor:pointer;
@@ -183,7 +180,12 @@
       background-size:cover !important;
       background-position:center !important;
       color:#fff !important;
-      border:1px solid #000 !important;
+      border:none !important;
       text-shadow:0 1px 2px rgba(0,0,0,.6);
       font-weight:700;
+    }
+
+    @media (min-width:600px){
+      .choices.tiles{grid-template-columns:repeat(3,1fr);}
+      button.tile{aspect-ratio: 1 / 2;}
     }


### PR DESCRIPTION
## Summary
- Make welcome screen tiles switch aspect ratio: 2:1 on narrow screens, 1:2 on wide screens
- Remove borders from tiles for cleaner look

## Testing
- `npm test` (fails: enoent package.json)
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9be701e688332ada1a4f0666302b5