### PR TITLE
Style scr-today without border or shadow

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -165,6 +165,13 @@
       box-shadow:none;
     }
 
+    /* Today's screen without card border or shadow */
+    #scr-today .card{
+      border:none;
+      box-shadow:none;
+      background:#DDD;
+    }
+
     /* Tile-style call to actions on welcome screen */
     #scr-welcome .choices.tiles{
       display:grid;


### PR DESCRIPTION
## Summary
- Remove border and drop shadow from the Today screen card
- Give the Today card a light gray background (#DDD)

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9caa2e7908332bb480e5c72d8406a