### PR TITLE
Limit Tools drawer content width

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -88,6 +88,7 @@
     /* Library drawer */
     .drawer{position:fixed; left:0; bottom:0; right:0; top:0; transform:translateY(100%); transition:.25s ease; background:var(--surface); border-top:1px solid var(--border); box-shadow:var(--shadow); z-index:100; overflow-y:auto;}
     .drawer.open{transform:translateY(0)}
+    .drawer > *{width:min(860px,94%); margin:0 auto;}
     .drawer .grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.6rem; padding:1rem}
     @media (max-width:720px){ .drawer .grid{grid-template-columns:1fr} }
 


### PR DESCRIPTION
## Summary
- Constrain Tools drawer content to match main page width for consistent layout

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9d1de57c4833287b41f15583dd5f0