### PR TITLE
fix: non-wrapping button labels with ellipsis

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -25,9 +25,9 @@
         <h1>We got you! Step by step you'll get there.</h1>
         <p class="muted">I’ll ask one or two things, then show just your next step.</p>
         <div class="choices tiles">
-          <button class="tile" data-choice="lost" style="--bg:url('img/home1b.png');">I just lost my job</button>
-          <button class="tile" data-choice="explore" style="--bg:url('img/home3.png');">I’m exploring a change</button>
-          <button class="tile" data-choice="stuck" style="--bg:url('img/home4b.png');">I’m stuck in my job</button>
+          <button class="tile" data-choice="lost" style="--bg:url('img/home1b.png');"><span class="label">I just lost my job</span></button>
+          <button class="tile" data-choice="explore" style="--bg:url('img/home3.png');"><span class="label">I’m exploring a change</span></button>
+          <button class="tile" data-choice="stuck" style="--bg:url('img/home4b.png');"><span class="label">I’m stuck in my job</span></button>
         </div>
         <button id="skip-intake" class="btn">Skip — just give me a plan</button>
       </div>

--- a/web/style.css
+++ b/web/style.css
@@ -199,6 +199,15 @@
       text-shadow:0 1px 2px rgba(0,0,0,.6);
       font-weight:700;
       font-size: clamp(1rem, 0.8rem + 1vw, 1.5rem);
+      min-width:0;
+    }
+
+    #scr-welcome .tile .label{
+      display:block;
+      max-width:100%;
+      white-space:nowrap;
+      overflow:hidden;
+      text-overflow:ellipsis;
     }
 
     @media (min-width:600px){


### PR DESCRIPTION
## Summary
- Prevent welcome screen tile labels from wrapping by wrapping text in span.label and CSS ellipsis rules
- Add min-width and ellipsis styling for #scr-welcome tile labels

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68a9d78f66b48332b9b4072553811fe0