### PR TITLE
Remove border from coach output windows

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -67,7 +67,7 @@
     .coach-header{display:flex; align-items:center; justify-content:space-between; padding:1rem; border-bottom:1px solid var(--border)}
     .coach-tools{display:flex; gap:.5rem; padding:.6rem 1rem; border-bottom:1px solid var(--border); flex-wrap:wrap}
     .coach-body{padding:1rem; overflow:auto}
-    .coach-output{background:var(--card); border:1px solid var(--border); border-radius:.8rem; padding:1rem}
+    .coach-output{background:var(--card); border:none; border-radius:.8rem; padding:1rem}
     .coach-output > .page{display:none}
     .coach-output > .page.active{display:block}
     .coach-pager{display:flex; justify-content:space-between; gap:.6rem; padding-top:.6rem}


### PR DESCRIPTION
## Summary
- remove 1px border from coach output component

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9d8a25d7083329cdda2bd582c53cb