### PR TITLE
Scale welcome tile text to fit without truncation

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -230,6 +230,19 @@
     const scrToday   = document.getElementById('scr-today');
     function show(id){ [scrWelcome,scrIntake,scrToday].forEach(s=>s.classList.remove('active')); id.classList.add('active'); }
 
+    function fitWelcomeTiles(){
+      document.querySelectorAll('#scr-welcome .tile .label').forEach(label => {
+        label.style.fontSize = '';
+        let size = parseFloat(getComputedStyle(label).fontSize);
+        while(label.scrollWidth > label.clientWidth && size > 8){
+          size -= 1;
+          label.style.fontSize = size + 'px';
+        }
+      });
+    }
+    fitWelcomeTiles();
+    window.addEventListener('resize', fitWelcomeTiles);
+
     // Reset (clear saved state)
     document.getElementById('reset').addEventListener('click', ()=>{
       localStorage.removeItem(stateKey);

--- a/web/style.css
+++ b/web/style.css
@@ -206,8 +206,7 @@
       display:block;
       max-width:100%;
       white-space:nowrap;
-      overflow:hidden;
-      text-overflow:ellipsis;
+      overflow:visible;
     }
 
     @media (min-width:600px){


### PR DESCRIPTION
## Summary
- Prevent tile labels on the welcome screen from truncating by removing ellipsis styling
- Dynamically shrink tile label text to fit within tiles while keeping it on a single line

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9dabb28b88332965b807e089ac48d