### PR TITLE
Clear weekly plan when phase changes

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -422,6 +422,9 @@ function fitWelcomeTiles(){
       userState.current_phase = phases.includes(p) ? p : 'stabilize';
       userState.week_in_phase = w;
       persist();
+      // Clear out old plan immediately and show loading state
+      planStatus.textContent = 'Generating weekly plan…';
+      planMd.innerHTML = '';
       closePhasePop();
       await initToday(); // refresh plan + tasks
     });


### PR DESCRIPTION
## Summary
- Clear old weekly plan and show "Generating weekly plan…" immediately when saving a new phase

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a9e77339808332bd402d5e82903470