### PR TITLE
Restyle tool tiles in drawer

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -92,6 +92,22 @@
     .drawer .grid{display:grid; grid-template-columns:repeat(2,minmax(0,1fr)); gap:.6rem; padding:1rem}
     @media (max-width:720px){ .drawer .grid{grid-template-columns:1fr} }
 
+    /* Tool tiles */
+    #drawer .card{
+      background:#f6f6f6;
+      border:none;
+      box-shadow:none;
+    }
+    #drawer .card h3{
+      margin:0 0 .3rem;
+    }
+    #drawer .card p{
+      margin:0 0 1rem;
+    }
+    #drawer .card .btn{
+      margin-top:1rem;
+    }
+
     /* Sprint panel */
     .sprint-panel{position:fixed; inset:0; display:none; align-items:center; justify-content:center; background:rgba(10,12,20,.65); backdrop-filter: blur(2px); z-index:130;}
     .sprint-panel.open{display:flex}


### PR DESCRIPTION
## Summary
- Remove border and shadow from tool tiles and give them a light grey background
- Adjust spacing within tool tiles so heading and text sit higher and buttons have more separation

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a9ee9b6fcc8332b5be953f68ae36e6