### PR TITLE
style: update phase chip colors

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -148,6 +148,16 @@
       color:#000 !important;
     }
 
+    /* Phase chip on Today screen: blue background, white text and chevron, white border */
+    #scr-today #phase-chip {
+      background:var(--accent) !important;
+      border:1px solid #fff !important;
+      color:#fff !important;
+    }
+    #scr-today #phase-chip:after {
+      color:#fff !important;
+    }
+
     /* Primary button style: blue background with white border and text */
 .btn-primary{
   background:var(--accent) !important;


### PR DESCRIPTION
## Summary
- style phase-chip in Today screen with blue background, white text and chevron, and white border

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a9f06afa68833297cb6619f57fe241