### PR TITLE
Show loading message during daily plan refresh

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -307,6 +307,7 @@ function fitWelcomeTiles(){
 
       planStatus.textContent = 'Generating weekly plan…';
       planMd.innerHTML = '';
+      todoList.innerHTML = '<li>Generating daily plan…</li>';
       const plan = await callCoach('plan', userState, 'Return a Weekly Plan; include a section starting with "Do today (90/30/15)".');
       const planWithTools = addToolsSection(plan);
       renderMarkdown(planWithTools, planMd);
@@ -421,6 +422,7 @@ function fitWelcomeTiles(){
       // Clear out old plan immediately and show loading state
       planStatus.textContent = 'Generating weekly plan…';
       planMd.innerHTML = '';
+      todoList.innerHTML = '<li>Generating daily plan…</li>';
       // Reset coach panel so stale content isn't shown
       const activeTool = document.querySelector('.coach-tools .btn.active');
       if (activeTool) {


### PR DESCRIPTION
## Summary
- Clear today's tasks and display a "Generating daily plan…" placeholder while loading
- Reset list immediately when phase changes via the phase chip

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68aa17f9cf4c8332a4483eb8e935c4b5