### PR TITLE
style: add speech bubbles for coach and user messages

### DIFF
--- a/web/style.css
+++ b/web/style.css
@@ -78,9 +78,17 @@
     .coach-footer{position:sticky; bottom:0; background:#007bff; display:flex; gap:.5rem; padding:1rem 1rem 1rem; border-top:1px solid var(--border)}
     .coach-input{flex:1; background:#fff; color:var(--text); border:none; border-radius:.7rem; padding:.7rem .9rem}
     .coach-input::placeholder{color:var(--muted)}
-    .msg{margin:.5rem 0; padding:.6rem .7rem; border-radius:.6rem}
-    .msg-user{background:rgba(255,255,255,.06)}
-    .msg-coach{background:transparent; border:1px dashed var(--border)}
+    .msg{margin:.5rem 0; padding:.6rem .7rem; border-radius:.6rem; position:relative}
+    .msg-user{background:#b5d9ff}
+    .msg-user::after{
+      content:""; position:absolute; bottom:0; right:-8px; width:0; height:0;
+      border-top:8px solid transparent; border-bottom:8px solid transparent; border-left:8px solid #b5d9ff;
+    }
+    .msg-coach{background:#f6f6f6}
+    .msg-coach::after{
+      content:""; position:absolute; bottom:0; left:-8px; width:0; height:0;
+      border-top:8px solid transparent; border-bottom:8px solid transparent; border-right:8px solid #f6f6f6;
+    }
 
     /* Library drawer */
     .drawer{position:fixed; left:0; bottom:0; right:0; top:0; transform:translateY(100%); transition:.25s ease; background:var(--surface); border-top:1px solid var(--border); box-shadow:var(--shadow); z-index:100; overflow-y:auto;}


### PR DESCRIPTION
## Summary
- style the coach and user message frames as speech bubbles
- add left and right bubble tails and color backgrounds

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68aa225cafc88332a8784a5fd75320d0