### PR TITLE
Add basic user authentication links

### DIFF
--- a/web/auth.js
+++ b/web/auth.js
@@ -1,0 +1,57 @@
+// Simple client-side authentication using localStorage
+// Shows auth links in header and handles sign-up/sign-in forms
+
+document.addEventListener('DOMContentLoaded', () => {
+  const authLinks = document.getElementById('auth-links');
+  const currentUser = localStorage.getItem('loggedInUser');
+
+  if (authLinks && currentUser) {
+    authLinks.innerHTML = `<span class="muted">Hi, ${currentUser}</span> <button id="logout" class="btn ghost">Log Out</button>`;
+    document.getElementById('logout').addEventListener('click', () => {
+      localStorage.removeItem('loggedInUser');
+      location.reload();
+    });
+  }
+
+  const signupForm = document.getElementById('signup-form');
+  if (signupForm) {
+    signupForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const username = document.getElementById('signup-username').value.trim();
+      const password = document.getElementById('signup-password').value;
+      const msg = document.getElementById('signup-msg');
+      if (!username || !password) {
+        msg.textContent = 'Please fill in all fields.';
+        return;
+      }
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+      if (users[username]) {
+        msg.textContent = 'User already exists.';
+        return;
+      }
+      users[username] = { password };
+      localStorage.setItem('users', JSON.stringify(users));
+      localStorage.setItem('loggedInUser', username);
+      msg.textContent = 'Sign-up successful!';
+      setTimeout(() => { window.location.href = 'index.html'; }, 800);
+    });
+  }
+
+  const signinForm = document.getElementById('signin-form');
+  if (signinForm) {
+    signinForm.addEventListener('submit', (e) => {
+      e.preventDefault();
+      const username = document.getElementById('signin-username').value.trim();
+      const password = document.getElementById('signin-password').value;
+      const msg = document.getElementById('signin-msg');
+      const users = JSON.parse(localStorage.getItem('users') || '{}');
+      if (users[username] && users[username].password === password) {
+        localStorage.setItem('loggedInUser', username);
+        msg.textContent = 'Sign-in successful!';
+        setTimeout(() => { window.location.href = 'index.html'; }, 800);
+      } else {
+        msg.textContent = 'Invalid credentials.';
+      }
+    });
+  }
+});

--- a/web/home.html
+++ b/web/home.html
@@ -11,6 +11,10 @@
   <div class="wrap">
     <header>
       <a class="logo" href="#"><span class="mark">N</span> NextChapter</a>
+      <div id="auth-links" style="display:flex; gap:.5rem;">
+        <a href="signup.html" class="btn ghost">Sign Up</a>
+        <a href="signin.html" class="btn ghost">Sign In</a>
+      </div>
     </header>
 
     <section class="screen active">
@@ -21,5 +25,6 @@
       </div>
     </section>
   </div>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/web/index.html
+++ b/web/index.html
@@ -13,9 +13,13 @@
   <div class="wrap">
     <header>
       <a class="logo" href="#"><span class="mark">N</span> NextChapter</a>
-      <div style="display:flex; gap:.5rem;">
+      <div style="display:flex; gap:.5rem; align-items:center;">
         <button id="open-library" class="btn ghost" aria-expanded="false">Tools</button>
         <button id="reset" class="btn ghost" title="Clear saved state">Reset</button>
+        <div id="auth-links" style="display:flex; gap:.5rem;">
+          <a href="signup.html" class="btn ghost">Sign Up</a>
+          <a href="signin.html" class="btn ghost">Sign In</a>
+        </div>
       </div>
     </header>
 
@@ -713,5 +717,6 @@ function fitWelcomeTiles(){
     // ---------- Auto-resume ----------
     if(userState.current_phase){ initToday(); }
   </script>
+  <script src="auth.js"></script>
 </body>
 </html>

--- a/web/signin.html
+++ b/web/signin.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign In</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
+  <div class="wrap">
+    <h1>Sign In</h1>
+    <form id="signin-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">
+      <div class="form-row">
+        <label for="signin-username" class="label">Username</label>
+        <input id="signin-username" class="input" type="text" autocomplete="off" required>
+      </div>
+      <div class="form-row">
+        <label for="signin-password" class="label">Password</label>
+        <input id="signin-password" class="input" type="password" required>
+      </div>
+      <button class="btn primary" type="submit">Sign In</button>
+      <p id="signin-msg" class="muted"></p>
+    </form>
+  </div>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/web/signup.html
+++ b/web/signup.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Sign Up</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
+  <div class="wrap">
+    <h1>Sign Up</h1>
+    <form id="signup-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">
+      <div class="form-row">
+        <label for="signup-username" class="label">Username</label>
+        <input id="signup-username" class="input" type="text" autocomplete="off" required>
+      </div>
+      <div class="form-row">
+        <label for="signup-password" class="label">Password</label>
+        <input id="signup-password" class="input" type="password" required>
+      </div>
+      <button class="btn primary" type="submit">Create Account</button>
+      <p id="signup-msg" class="muted"></p>
+    </form>
+  </div>
+  <script src="auth.js"></script>
+</body>
+</html>

--- a/web/style.css
+++ b/web/style.css
@@ -133,7 +133,7 @@
     }
     .phase-card h3{margin:.1rem 0 .2rem}
     .form-row{display:grid; gap:.3rem}
-    .select, .number{
+    .select, .number, .input{
       appearance:none; width:100%; background:var(--surface); color:var(--text);
       border:1px solid var(--border); border-radius:.6rem; padding:.6rem .7rem;
     }


### PR DESCRIPTION
## Summary
- Add sign up and sign in links to the header with client-side auth state
- Introduce localStorage-based auth handler and dedicated sign up/sign in pages
- Style inputs for auth forms to match existing design

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68aac595d1508332a73b4521487ca1e3