### PR TITLE
Add verification email helper and dev test route

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,8 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 - Set `APP_BASE_URL` (e.g., `https://nextchapter.onrender.com`).
 - Test locally: `/_mail_reset_test?to=you@domain.com&token=demo`.
 - On Render, configure `SMTP_*`, `EMAIL_*`, and optionally `APP_BASE_URL`.
+
+## Signup verification email
+- Set `APP_BASE_URL` (e.g., `https://nextchapter.onrender.com`).
+- Test locally: `/_mail_verify_test?to=you@domain.com&token=demo`.
+- In production, configure `SMTP_*`, `EMAIL_*`, and `APP_BASE_URL`.

--- a/app.py
+++ b/app.py
@@ -2,7 +2,7 @@ import os, json, traceback
 from flask import Flask, request, jsonify, send_from_directory
 from dotenv import load_dotenv
 from openai import OpenAI
-from mailer import send_mail, send_password_reset_email
+from mailer import send_mail, send_password_reset_email, send_verification_email
 
 # --- Load config ---
 load_dotenv()
@@ -212,6 +212,26 @@ def _mail_reset_test():
         return "Missing ?to=<email>", 400
     try:
         send_password_reset_email(to, token)
+        return "OK", 200
+    except Exception as e:
+        return str(e), 500
+
+
+@app.get("/_mail_verify_test")
+def _mail_verify_test():
+    """
+    Dev-only helper: sends a verification email to ?to=<email>
+    with a dummy or provided ?token=<token>. Disabled in production.
+    """
+    if os.getenv("ENV", "development").lower() == "production":
+        return "Not available in production", 404
+
+    to = request.args.get("to")
+    token = request.args.get("token", "demo-verify-token")
+    if not to:
+        return "Missing ?to=<email>", 400
+    try:
+        send_verification_email(to, token)
         return "OK", 200
     except Exception as e:
         return str(e), 500

--- a/mailer.py
+++ b/mailer.py
@@ -58,3 +58,20 @@ def send_password_reset_email(to_addr: str, token: str):
 
     # reuse existing helper
     send_mail(to_addr, subject, text, html)
+
+
+def send_verification_email(to_addr: str, token: str):
+    """
+    Compose and send an email verification message.
+    Builds a link using APP_BASE_URL (defaults to https://nextchapter.onrender.com).
+    """
+    base_url = os.getenv("APP_BASE_URL", "https://nextchapter.onrender.com")
+    verify_path = "/verify"
+    verify_url = f"{base_url.rstrip('/')}{verify_path}?{urlencode({'token': token})}"
+
+    subject = "Confirm your email"
+    text = f"Please confirm your email by clicking: {verify_url}"
+    html = f"""<p>Please confirm your email by clicking the link below:</p>
+               <p><a href=\"{verify_url}\">{verify_url}</a></p>"""
+
+    send_mail(to_addr, subject, text, html)


### PR DESCRIPTION
## Summary
- add reusable helper to send email verification links
- provide dev-only endpoint to trigger verification emails
- document verification email config and testing

## Testing
- `python -m py_compile mailer.py app.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ab29fc1f108332852bd8cbdede8297