### PR TITLE
Add SQLAlchemy user/token scaffolding and init DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,3 +46,8 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 - Verification link format: GET `/verify?token=...`
 - In `ENV=development`, any non-empty token is accepted by the stub
 - Real implementations should replace `validate_verification_token()` and `mark_user_verified()` with DB-backed logic
+
+## Database
+- Set `DATABASE_URL` in Render to your Postgres connection string
+- Tables are auto-created on startup (no migrations yet)
+- We’ll wire real token + user operations in subsequent steps

--- a/app.py
+++ b/app.py
@@ -13,6 +13,8 @@ from auth_utils import (
 
 # --- Load config ---
 load_dotenv()
+from db import init_db
+init_db()
 OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 MODEL = os.getenv("MODEL", "gpt-4o-mini")          # safe default
 FALLBACK_MODEL = os.getenv("FALLBACK_MODEL", "gpt-4o-mini")

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,5 +1,6 @@
 import os
 from typing import Optional
+from db import get_session, find_user_by_email, create_user, issue_token, validate_token, mark_token_used
 from werkzeug.security import generate_password_hash
 
 def validate_reset_token(token: str) -> Optional[dict]:

--- a/db.py
+++ b/db.py
@@ -1,0 +1,97 @@
+# db.py
+import os
+from datetime import datetime, timedelta
+from typing import Optional, Literal
+from sqlalchemy import (
+    create_engine, Column, Integer, String, Boolean, DateTime, ForeignKey, Index, text
+)
+from sqlalchemy.orm import declarative_base, relationship, sessionmaker, Session
+
+DATABASE_URL = os.getenv("DATABASE_URL", "").strip()
+# Render / Heroku style URLs sometimes start with postgres://; SQLAlchemy wants postgresql://
+if DATABASE_URL.startswith("postgres://"):
+    DATABASE_URL = DATABASE_URL.replace("postgres://", "postgresql://", 1)
+
+engine = create_engine(DATABASE_URL or "sqlite:///:memory:", future=True, pool_pre_ping=True)
+SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+Base = declarative_base()
+
+
+class User(Base):
+    __tablename__ = "users"
+    id = Column(Integer, primary_key=True)
+    email = Column(String(255), unique=True, index=True, nullable=False)
+    password_hash = Column(String(255), nullable=True)  # may be None until set
+    is_verified = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    tokens = relationship("EmailToken", back_populates="user", cascade="all, delete-orphan")
+
+
+class EmailToken(Base):
+    __tablename__ = "email_tokens"
+    id = Column(Integer, primary_key=True)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False, index=True)
+    token = Column(String(255), unique=True, index=True, nullable=False)
+    purpose = Column(String(20), nullable=False)  # 'reset' or 'verify'
+    expires_at = Column(DateTime, nullable=False)
+    used_at = Column(DateTime, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+
+    user = relationship("User", back_populates="tokens")
+
+
+Index("ix_email_tokens_active", EmailToken.token, EmailToken.purpose)
+
+
+def init_db() -> None:
+    """Create tables if they don't exist."""
+    Base.metadata.create_all(engine)
+
+
+def get_session() -> Session:
+    return SessionLocal()
+
+
+# Convenience helpers we will use in later steps
+def create_user(sess: Session, email: str, password_hash: Optional[str] = None) -> User:
+    u = User(email=email.lower().strip(), password_hash=password_hash, is_verified=False)
+    sess.add(u)
+    sess.flush()
+    return u
+
+
+def find_user_by_email(sess: Session, email: str) -> Optional[User]:
+    return sess.query(User).filter(User.email == email.lower().strip()).one_or_none()
+
+
+def issue_token(
+    sess: Session, user: User, token: str, purpose: Literal["reset", "verify"], ttl_minutes: int = 60
+) -> EmailToken:
+    t = EmailToken(
+        user_id=user.id,
+        token=token,
+        purpose=purpose,
+        expires_at=datetime.utcnow() + timedelta(minutes=ttl_minutes),
+    )
+    sess.add(t)
+    sess.flush()
+    return t
+
+
+def validate_token(sess: Session, token: str, purpose: Literal["reset", "verify"]) -> Optional[EmailToken]:
+    now = datetime.utcnow()
+    t = (
+        sess.query(EmailToken)
+        .filter(EmailToken.token == token, EmailToken.purpose == purpose)
+        .one_or_none()
+    )
+    if not t or t.used_at is not None or t.expires_at < now:
+        return None
+    return t
+
+
+def mark_token_used(sess: Session, t: EmailToken) -> None:
+    t.used_at = datetime.utcnow()
+    sess.add(t)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai>=1.40.0
 python-dotenv>=1.0.1
 gunicorn==22.0.0
 Werkzeug>=3.1.3
+SQLAlchemy>=2.0.32
+psycopg2-binary>=2.9.9


### PR DESCRIPTION
## Summary
- add SQLAlchemy models for `User` and `EmailToken` plus helper utilities
- hook application startup to create database tables and expose helpers
- document DATABASE_URL configuration and add DB deps

## Testing
- `python -m py_compile app.py auth_utils.py db.py`
- `pip install SQLAlchemy psycopg2-binary` *(fails: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68ab3a1040a88332adc001a2cd713619