### PR TITLE
Use DB-backed auth utils and consume tokens

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,6 +9,7 @@ from auth_utils import (
     set_user_password,
     validate_verification_token,
     mark_user_verified,
+    consume_token,
 )
 from sqlalchemy import text
 
@@ -260,6 +261,7 @@ def reset_submit():
 
     phash = hash_password(password)
     set_user_password(user["user_id"], phash)
+    consume_token(token, "reset")
     return render_template_string(RESET_SUCCESS_HTML), 200
 
 
@@ -292,6 +294,7 @@ def verify_view():
         return render_template_string(VERIFY_ERROR_HTML, message="Invalid or expired verification link."), 400
     try:
         mark_user_verified(user["user_id"])
+        consume_token(token, "verify")
     except Exception as e:
         # Log and show a generic error
         import logging


### PR DESCRIPTION
## Summary
- implement database-backed token validation and user updates with dev fallbacks
- consume tokens after successful reset or verification

## Testing
- `python -m py_compile auth_utils.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab422fa9b88332bd3de932883c0668