### PR TITLE
Add dev token issuer endpoint for testing DB tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,10 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 - Test locally: `/_mail_verify_test?to=you@domain.com&token=demo`.
 - In production, configure `SMTP_*`, `EMAIL_*`, and `APP_BASE_URL`.
 
+## Dev token issuer
+- `/_dev_issue_token?email=<e>&purpose=reset|verify&ttl=60&send=true`
+- Only available when `ENV != production`.
+
 ## Email verification flow
 - Verification link format: GET `/verify?token=...`
 - In `ENV=development`, any non-empty token is accepted by the stub


### PR DESCRIPTION
## Summary
- add `_dev_issue_token` endpoint to create DB tokens and optionally send email
- document dev token issuer usage in README

## Testing
- `pytest`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab4aecb07483328a8c00491caf74c1