### PR TITLE
feat: add password reset request endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,3 +60,8 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 - `POST /signup {email, password}` → creates user and emails verify link.
 - `POST /login {email, password}` → logs in if verified.
 - Both return JSON. In production you’d add sessions/JWT; here we return raw JSON for simplicity.
+
+## Forgot password
+- `POST /forgot_password {email}` → returns generic success.
+- If the user exists, a reset token is created and an email is sent.
+- Reset link goes to `/reset?token=...`.


### PR DESCRIPTION
## Summary
- implement `/forgot_password` endpoint to issue reset tokens and send emails without exposing account existence
- document password reset request API in README

## Testing
- `python -m py_compile app.py auth_utils.py db.py mailer.py && echo 'py_compile passed'`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68ab571a636c83329c6233c6918bd229