### PR TITLE
Expose and update user phase on homepage

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,3 +72,4 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 - `GET /me?email=...` → returns `{ id, email, phase }`.
 - `POST /login` now includes the user's phase in the response.
 - Identity uses email for now; sessions/JWT will replace this later.
+- Front-end reads `loggedInEmail` from localStorage and highlights the active phase; clicking a phase persists it.

--- a/web/auth.js
+++ b/web/auth.js
@@ -60,6 +60,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         if (res.ok && data.ok) {
           localStorage.setItem('loggedInUser', data.user.email);
+          localStorage.setItem('loggedInEmail', data.user.email);
           msg.textContent = 'Sign-in successful!';
           setTimeout(() => { window.location.href = 'index.html'; }, 800);
         } else {

--- a/web/index.html
+++ b/web/index.html
@@ -8,6 +8,9 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
   <link rel="stylesheet" href="style.css">
+  <style>
+  .phase.active { font-weight: 700; text-decoration: underline; }
+  </style>
 </head>
 <body style="display:none">
   <div class="wrap">
@@ -22,6 +25,15 @@
         </div>
       </div>
     </header>
+
+    <ul id="phase-choices">
+      <li data-phase="explore" class="phase">Explore</li>
+      <li data-phase="apply" class="phase">Apply</li>
+      <li data-phase="interview" class="phase">Interview</li>
+      <li data-phase="offer" class="phase">Offer</li>
+      <li data-phase="decide" class="phase">Decide</li>
+      <li data-phase="onboard" class="phase">Onboard</li>
+    </ul>
 
     <!-- Screen 1: Welcome -->
     <section id="scr-welcome" class="screen active">
@@ -718,5 +730,6 @@ function fitWelcomeTiles(){
     if(userState.current_phase){ initToday(); }
   </script>
   <script src="auth.js"></script>
+  <script src="phase.js"></script>
 </body>
 </html>

--- a/web/phase.js
+++ b/web/phase.js
@@ -1,0 +1,56 @@
+(function () {
+  const API_BASE = ""; // same origin
+
+  function getEmail() {
+    // wherever you store the logged-in email (adjust if your key differs)
+    return localStorage.getItem("loggedInEmail") || "";
+  }
+
+  function setActivePhase(phase) {
+    document.querySelectorAll(".phase").forEach(el => {
+      el.classList.toggle("active", el.dataset.phase === phase);
+    });
+  }
+
+  async function fetchMeAndRender() {
+    const email = getEmail();
+    if (!email) return; // not logged in
+
+    const res = await fetch(`${API_BASE}/me?email=` + encodeURIComponent(email));
+    const data = await res.json();
+    if (data.ok && data.user) {
+      setActivePhase(data.user.phase || "explore");
+    }
+  }
+
+  async function updatePhase(newPhase) {
+    const email = getEmail();
+    if (!email) return;
+    const res = await fetch(`${API_BASE}/phase`, {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({ email, phase: newPhase })
+    });
+    const data = await res.json();
+    if (data.ok && data.user) {
+      setActivePhase(data.user.phase);
+    } else {
+      console.warn("Phase update failed:", data);
+      alert(data.error || "Could not update phase");
+    }
+  }
+
+  function bindPhaseClicks() {
+    document.querySelectorAll(".phase").forEach(el => {
+      el.addEventListener("click", () => {
+        const p = el.dataset.phase;
+        if (p) updatePhase(p);
+      });
+    });
+  }
+
+  document.addEventListener("DOMContentLoaded", () => {
+    bindPhaseClicks();
+    fetchMeAndRender();
+  });
+})();


### PR DESCRIPTION
## Summary
- highlight active phase on the homepage and allow switching phases
- store loggedInEmail at sign-in and use it for phase API calls
- document phase endpoints and client behaviour

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab65b694b4833297e2aa90a39abefe