### PR TITLE
Remove duplicate phase navbar and centralize phase state

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -8,11 +8,8 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/dompurify@3.1.6/dist/purify.min.js"></script>
   <link rel="stylesheet" href="style.css">
-  <style>
-  .phase.active { font-weight: 700; text-decoration: underline; }
-  </style>
 </head>
-<body style="display:none">
+<body id="app-root" data-current-phase="explore" style="display:none">
   <div class="wrap">
     <header>
       <a class="logo" href="#"><span class="mark">N</span> NextChapter</a>
@@ -25,15 +22,6 @@
         </div>
       </div>
     </header>
-
-    <ul id="phase-choices">
-      <li data-phase="explore" class="phase">Explore</li>
-      <li data-phase="apply" class="phase">Apply</li>
-      <li data-phase="interview" class="phase">Interview</li>
-      <li data-phase="offer" class="phase">Offer</li>
-      <li data-phase="decide" class="phase">Decide</li>
-      <li data-phase="onboard" class="phase">Onboard</li>
-    </ul>
 
     <!-- Screen 1: Welcome -->
     <section id="scr-welcome" class="screen active">
@@ -117,7 +105,7 @@
       <div class="card panel today">
         <div style="display:flex; justify-content:space-between; align-items:center; gap:1rem">
           <!-- Phase pill is a button -->
-          <button id="phase-chip" class="phase" type="button" aria-haspopup="dialog" aria-expanded="false">Phase · Week</button>
+          <button id="phase-chip" class="phase" type="button" aria-haspopup="dialog" aria-expanded="false"><span id="phase-pill-label">Phase</span> · Week</button>
           <button id="btn-standup" class="btn ghost">Daily check-in</button>
         </div>
         <div class="todo">
@@ -141,15 +129,15 @@
     <div class="phase-card">
       <h3 id="phase-pop-title">Adjust phase & week</h3>
       <div class="form-row">
-        <label for="phase-select" class="label">Phase</label>
-        <select id="phase-select" class="select">
-          <option value="stabilize">Stabilize</option>
-          <option value="reframe">Reframe</option>
-          <option value="position">Position</option>
-          <option value="explore">Explore</option>
-          <option value="apply">Apply</option>
-          <option value="secure">Secure</option>
-          <option value="transition">Transition</option>
+        <label for="intake-phase" class="label">Phase</label>
+        <select id="intake-phase" class="select">
+          <option value="stabilize" class="pill-option" data-phase="stabilize">Stabilize</option>
+          <option value="reframe" class="pill-option" data-phase="reframe">Reframe</option>
+          <option value="position" class="pill-option" data-phase="position">Position</option>
+          <option value="explore" class="pill-option" data-phase="explore">Explore</option>
+          <option value="apply" class="pill-option" data-phase="apply">Apply</option>
+          <option value="secure" class="pill-option" data-phase="secure">Secure</option>
+          <option value="transition" class="pill-option" data-phase="transition">Transition</option>
         </select>
       </div>
       <div class="form-row">
@@ -353,7 +341,7 @@ function fitWelcomeTiles(){
       const phaseLabel = (typeof cap === "function")
         ? cap(userState.current_phase || 'stabilize')
         : (userState.current_phase || 'stabilize');
-      phaseChip.textContent = `${phaseLabel} · Week ${userState.week_in_phase || 1}`;
+      phaseChip.innerHTML = `<span id="phase-pill-label">${phaseLabel}</span> · Week ${userState.week_in_phase || 1}`;
       show(scrToday);
 
       planStatus.textContent = 'Generating weekly plan…';
@@ -406,7 +394,7 @@ function fitWelcomeTiles(){
 
     // ---------- Phase popover logic ----------
     const phasePop = document.getElementById('phase-pop');
-    const phaseSelect = document.getElementById('phase-select');
+    const phaseSelect = document.getElementById('intake-phase');
     const weekInput = document.getElementById('week-input');
     const phaseCancel = document.getElementById('phase-cancel');
     const phaseSave = document.getElementById('phase-save');

--- a/web/phase.js
+++ b/web/phase.js
@@ -1,56 +1,98 @@
 (function () {
-  const API_BASE = ""; // same origin
+  const API = "";
+  const root = document.getElementById("app-root");
+  const pillLabel = document.getElementById("phase-pill-label");
 
   function getEmail() {
-    // wherever you store the logged-in email (adjust if your key differs)
     return localStorage.getItem("loggedInEmail") || "";
   }
 
-  function setActivePhase(phase) {
-    document.querySelectorAll(".phase").forEach(el => {
-      el.classList.toggle("active", el.dataset.phase === phase);
+  function normalize(s) {
+    return (s || "").trim().toLowerCase();
+  }
+
+  function setUIPhase(phaseKey) {
+    if (!phaseKey) return;
+    if (pillLabel) {
+      pillLabel.textContent = phaseKey.charAt(0).toUpperCase() + phaseKey.slice(1);
+    }
+    document.querySelectorAll(".pill-option[data-phase]").forEach(el => {
+      el.classList.toggle("is-active", normalize(el.dataset.phase) === phaseKey);
     });
+    if (root) root.setAttribute("data-current-phase", phaseKey);
+    const select = document.getElementById("intake-phase");
+    if (select) {
+      select.value = phaseKey;
+    } else {
+      document
+        .querySelectorAll('#intake-phase-group input[name="phase"]')
+        .forEach(r => (r.checked = normalize(r.value) === phaseKey));
+    }
   }
 
   async function fetchMeAndRender() {
     const email = getEmail();
-    if (!email) return; // not logged in
-
-    const res = await fetch(`${API_BASE}/me?email=` + encodeURIComponent(email));
-    const data = await res.json();
-    if (data.ok && data.user) {
-      setActivePhase(data.user.phase || "explore");
+    if (!email) return;
+    try {
+      const res = await fetch(`${API}/me?email=` + encodeURIComponent(email));
+      const data = await res.json();
+      if (data.ok && data.user) setUIPhase(normalize(data.user.phase || "explore"));
+    } catch (e) {
+      console.warn("Failed to fetch /me:", e);
     }
   }
 
-  async function updatePhase(newPhase) {
+  async function savePhase(phaseKey) {
     const email = getEmail();
     if (!email) return;
-    const res = await fetch(`${API_BASE}/phase`, {
-      method: "POST",
-      headers: {"Content-Type": "application/json"},
-      body: JSON.stringify({ email, phase: newPhase })
-    });
-    const data = await res.json();
-    if (data.ok && data.user) {
-      setActivePhase(data.user.phase);
-    } else {
-      console.warn("Phase update failed:", data);
-      alert(data.error || "Could not update phase");
+    try {
+      const res = await fetch(`${API}/phase`, {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ email, phase: phaseKey })
+      });
+      const data = await res.json();
+      if (data.ok && data.user) {
+        setUIPhase(normalize(data.user.phase));
+      } else {
+        console.warn("Phase update failed", data);
+        alert(data.error || "Could not update phase");
+      }
+    } catch (e) {
+      console.error("Phase update error:", e);
+      alert("Network error saving phase");
     }
   }
 
-  function bindPhaseClicks() {
-    document.querySelectorAll(".phase").forEach(el => {
+  function bindPill() {
+    document.querySelectorAll(".pill-option[data-phase]").forEach(el => {
       el.addEventListener("click", () => {
-        const p = el.dataset.phase;
-        if (p) updatePhase(p);
+        const phaseKey = normalize(el.dataset.phase);
+        if (phaseKey) savePhase(phaseKey);
+      });
+    });
+  }
+
+  function bindIntake() {
+    const select = document.getElementById("intake-phase");
+    if (select) {
+      select.addEventListener("change", () => {
+        const val = normalize(select.value);
+        if (val) savePhase(val);
+      });
+      return;
+    }
+    const radios = document.querySelectorAll('#intake-phase-group input[name="phase"]');
+    radios.forEach(r => {
+      r.addEventListener("change", () => {
+        if (r.checked) savePhase(normalize(r.value));
       });
     });
   }
 
   document.addEventListener("DOMContentLoaded", () => {
-    bindPhaseClicks();
+    bindPill();
+    bindIntake();
     fetchMeAndRender();
   });
 })();


### PR DESCRIPTION
## Summary
- Remove temporary phase navigation and rely on existing pill and intake field
- Tag phase pill and intake select with stable IDs/data-phase attributes
- Introduce phase.js to sync user phase from API and persist changes

## Testing
- `python3 -m py_compile app.py db.py auth_utils.py mailer.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab6a786c9883329a0daa8f484dda5e