### PR TITLE
Update allowed phase list for user endpoints

### DIFF
--- a/app.py
+++ b/app.py
@@ -133,19 +133,28 @@ def me():
         user = find_user_by_email(sess, email)
         if not user:
             return jsonify({"ok": False, "error": "not found"}), 404
-        return jsonify({"ok": True, "user": {"id": user.id, "email": user.email, "phase": user.phase}})
+        phase = user.phase if user.phase in ALLOWED_PHASES else "stabilize"
+        return jsonify({"ok": True, "user": {"id": user.id, "email": user.email, "phase": phase}})
     finally:
         sess.close()
 
 
-ALLOWED_PHASES = {"explore", "apply", "interview", "offer", "decide", "onboard"}
+ALLOWED_PHASES = {
+    "stabilize",
+    "reframe",
+    "position",
+    "explore",
+    "apply",
+    "secure",
+    "transition",
+}
 
 
 @app.post("/phase")
 def set_phase():
     """
     TEMP (no sessions yet): Accepts JSON { email, phase } and updates user's phase.
-    Valid phases: explore, apply, interview, offer, decide, onboard.
+    Valid phases: stabilize, reframe, position, explore, apply, secure, transition.
     """
     data = request.get_json(silent=True) or {}
     email = (data.get("email") or "").strip().lower()


### PR DESCRIPTION
## Summary
- restrict `ALLOWED_PHASES` to the new seven-phase journey
- fall back to `stabilize` in `/me` when user phase is outside the allow-list

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_68ab6d27cbf4833283ec1c5bd6a41ce3