### PR TITLE
Use session-based phase endpoints

### DIFF
--- a/web/auth.js
+++ b/web/auth.js
@@ -54,6 +54,7 @@ document.addEventListener('DOMContentLoaded', () => {
       try {
         const res = await fetch('/login', {
           method: 'POST',
+          credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password })
         });


### PR DESCRIPTION
## Summary
- stop sending email for phase lookups and updates
- read `csrf_token` cookie and send as `X-CSRF-Token` when saving phase
- login now uses `credentials: "include"` so cookies persist

## Testing
- `pytest`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ac14eb70848332bbcf301c612b4df4