### PR TITLE
Use bcrypt hashing and secure password reset tokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ curl -X POST http://localhost:5055/plan   -H "Content-Type: application/json"   
 
 ## Password reset email
 - Set `APP_BASE_URL` (e.g., `https://nextchapter.onrender.com`).
-- Test locally: `/_mail_reset_test?to=you@domain.com&token=demo`.
+- Test locally: `/_mail_reset_test?to=you@domain.com`.
 - On Render, configure `SMTP_*`, `EMAIL_*`, and optionally `APP_BASE_URL`.
 
 ## Signup verification email
 - Set `APP_BASE_URL` (e.g., `https://nextchapter.onrender.com`).
-- Test locally: `/_mail_verify_test?to=you@domain.com&token=demo`.
+- Test locally: `/_mail_verify_test?to=you@domain.com`.
 - In production, configure `SMTP_*`, `EMAIL_*`, and `APP_BASE_URL`.
 
 ## Dev token issuer

--- a/auth_utils.py
+++ b/auth_utils.py
@@ -1,6 +1,5 @@
 import os
 from typing import Optional, Literal
-from werkzeug.security import generate_password_hash
 from db import get_session, validate_token, mark_token_used
 from db import SessionLocal  # if you prefer direct sessions
 from db import User  # for lookups/updates
@@ -27,9 +26,6 @@ def validate_reset_token(token: str) -> Optional[dict]:
         return {"user_id": t.user.id, "email": t.user.email}
     finally:
         sess.close()
-
-def hash_password(plain: str) -> str:
-    return generate_password_hash(plain)
 
 def set_user_password(user_id: int, password_hash: str) -> None:
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ gunicorn==22.0.0
 Werkzeug>=3.1.3
 SQLAlchemy>=2.0.32
 psycopg2-binary>=2.9.9
+bcrypt>=4.1.2


### PR DESCRIPTION
## Summary
- Switch password hashing and verification to bcrypt.
- Store email tokens as SHA-256 hashes with expiry and single-use tracking.
- Remove demo token fallbacks in dev mail helpers.

## Testing
- `pip install -r requirements.txt` *(fails: Could not connect to proxy for bcrypt)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ac175f14808332bb393cc4ab966a9d