### PR TITLE
Handle legacy password hashes and add admin reset endpoint

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,5 @@ gunicorn==22.0.0
 Werkzeug>=3.1.3
 SQLAlchemy>=2.0.32
 psycopg2-binary>=2.9.9
-bcrypt>=4.1.2
-flask-limiter>=3.5.0
+bcrypt>=4.1
+flask-limiter>=3.5


### PR DESCRIPTION
## Summary
- add helpers for bcrypt hashing and legacy detection
- harden login to avoid 500s on non-bcrypt hashes and issue CSRF cookie
- store bcrypt hashes on signup and reset; add admin password setup endpoint

## Testing
- `python -m py_compile app.py auth_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac3feac8548332b5b44d66e242942c