### PR TITLE
Handle unauthenticated /me and add data-url favicon

### DIFF
--- a/web/auth.js
+++ b/web/auth.js
@@ -10,8 +10,12 @@ document.addEventListener('DOMContentLoaded', () => {
   const authLinks = document.getElementById('auth-links');
 
   if (authLinks) {
-    fetch('/me', { credentials: 'include' })
-      .then(r => r.ok ? r.json() : null)
+    fetch('/me', {credentials: 'include'})
+      .then(r => {
+        if (r.status === 401) return null;
+        if (!r.ok) throw new Error('me failed');
+        return r.json();
+      })
       .then(data => {
         if (!data || !data.user) return;
         authLinks.innerHTML = `<span class="muted">Hi, ${data.user.email}</span> <button id="logout" class="btn ghost">Log Out</button>`;
@@ -74,7 +78,7 @@ document.addEventListener('DOMContentLoaded', () => {
         const data = await res.json();
         if (res.ok && data.ok) {
           msg.textContent = 'Sign-in successful!';
-          setTimeout(() => { window.location.href = 'index.html'; }, 800);
+          setTimeout(() => { location.reload(); }, 800);
         } else {
           msg.textContent = data.error || 'Invalid credentials.';
         }

--- a/web/index.html
+++ b/web/index.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>NextChapter — Calm Start</title>
   <meta name="description" content="A quiet, agent-first guide for job loss or career change. One next step at a time." />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Ccircle cx='8' cy='8' r='8' fill='%23000'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="/style.css?v=1">
 </head>
 <body id="app-root">

--- a/web/init.js
+++ b/web/init.js
@@ -11,8 +11,12 @@ document.addEventListener('DOMContentLoaded', () => {
     chip.addEventListener('change', e => window.savePhase(String(e.target.value || '').toLowerCase()));
   }
 
-  fetch('/me', { credentials: 'include' })
-    .then(r => r.ok ? r.json() : null)
+  fetch('/me', {credentials: 'include'})
+    .then(r => {
+      if (r.status === 401) return null;
+      if (!r.ok) throw new Error('me failed');
+      return r.json();
+    })
     .then(data => {
       if (!data || !data.user) return;
       const phase = String(data.user.phase || '').toLowerCase();


### PR DESCRIPTION
## Summary
- Treat `/me` 401 responses as unauthenticated without console errors
- Ensure login posts include credentials and reload on success
- Embed SVG favicon via data URL to avoid 404

## Testing
- ⚠️ `npm test` (no package.json)
- ⚠️ `python -m pytest` (no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68ac6899bd888332a4b2e76c40b9d3cb