### PR TITLE
Use hashed email tokens only

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,8 +1,9 @@
-# db.py
 import hashlib
 from datetime import datetime, timedelta
 from typing import Optional, Literal
+
 from sqlalchemy.orm import Session
+
 from models import User, EmailToken
 
 
@@ -18,9 +19,12 @@ def find_user_by_email(sess: Session, email: str) -> Optional[User]:
 
 
 def issue_token(
-    sess: Session, user: User, token: str, purpose: Literal["reset", "verify"], ttl_minutes: int = 60
+    sess: Session,
+    user: User,
+    token_hash: str,
+    purpose: Literal["reset", "verify"],
+    ttl_minutes: int = 60,
 ) -> EmailToken:
-    token_hash = hashlib.sha256(token.encode()).hexdigest()
     t = EmailToken(
         user_id=user.id,
         token_hash=token_hash,
@@ -50,4 +54,12 @@ def validate_token(sess: Session, token: str, purpose: Literal["reset", "verify"
 
 def mark_token_used(sess: Session, t: EmailToken) -> None:
     t.used = True
+    t.used_at = datetime.utcnow()
     sess.add(t)
+
+
+def cleanup_tokens(sess: Session) -> int:
+    now = datetime.utcnow()
+    deleted = sess.query(EmailToken).filter(EmailToken.expires_at <= now).delete()
+    sess.commit()
+    return deleted

--- a/models.py
+++ b/models.py
@@ -1,6 +1,16 @@
-from sqlalchemy import Column, String, Integer, Boolean, DateTime, ForeignKey
+from sqlalchemy import (
+    Column,
+    String,
+    Integer,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    text,
+)
 from sqlalchemy.orm import declarative_base, relationship
 import datetime
+
 
 Base = declarative_base()
 
@@ -8,17 +18,88 @@ class User(Base):
     __tablename__ = "users"
     id = Column(Integer, primary_key=True)
     email = Column(String, unique=True, nullable=False)
-    password_hash = Column(String, nullable=False)
-    phase = Column(String, default="explore")
-    is_verified = Column(Boolean, default=False)
-    created_at = Column(DateTime, default=datetime.datetime.utcnow)
+    password_hash = Column(String, nullable=True)
+    is_verified = Column(Boolean, nullable=False, default=False)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.datetime.utcnow)
+    phase = Column(String, nullable=False, default="explore")
 
 class EmailToken(Base):
     __tablename__ = "email_tokens"
     id = Column(Integer, primary_key=True)
-    user_id = Column(Integer, ForeignKey("users.id"))
-    token_hash = Column(String, unique=True, nullable=False)
-    type = Column(String)  # 'reset' or 'verify'
-    expires_at = Column(DateTime, nullable=False)
-    used = Column(Boolean, default=False)
+    user_id = Column(Integer, ForeignKey("users.id", ondelete="CASCADE"), nullable=False)
+    token_hash = Column(String, nullable=False)
+    type = Column(String, nullable=False)  # 'reset' or 'verify'
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.datetime.utcnow)
+    expires_at = Column(DateTime(timezone=True), nullable=False)
+    used = Column(Boolean, nullable=False, default=False)
+    used_at = Column(DateTime(timezone=True), nullable=True)
     user = relationship("User")
+
+
+Index("idx_email_tokens_hash", EmailToken.token_hash)
+Index("idx_email_tokens_user_type_used", EmailToken.user_id, EmailToken.type, EmailToken.used)
+
+
+def create_tables(engine):
+    """Create users and email_tokens tables if they do not exist."""
+    with engine.begin() as conn:
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS users (
+                    id SERIAL PRIMARY KEY,
+                    email TEXT UNIQUE NOT NULL,
+                    password_hash TEXT,
+                    is_verified BOOLEAN NOT NULL DEFAULT FALSE,
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    phase TEXT NOT NULL DEFAULT 'explore'
+                );
+                """
+            )
+        )
+        conn.execute(
+            text(
+                """
+                CREATE TABLE IF NOT EXISTS email_tokens (
+                    id SERIAL PRIMARY KEY,
+                    user_id INTEGER NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+                    token_hash TEXT NOT NULL,
+                    type TEXT NOT NULL CHECK (type IN ('reset','verify')),
+                    created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                    expires_at TIMESTAMPTZ NOT NULL,
+                    used BOOLEAN NOT NULL DEFAULT FALSE,
+                    used_at TIMESTAMPTZ NULL
+                );
+                """
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS idx_email_tokens_hash ON email_tokens(token_hash);"
+            )
+        )
+        conn.execute(
+            text(
+                "CREATE INDEX IF NOT EXISTS idx_email_tokens_user_type_used ON email_tokens(user_id, type, used);"
+            )
+        )
+
+
+def safe_migrate(engine):
+    """Perform idempotent schema migrations for email_tokens."""
+    with engine.begin() as conn:
+        conn.execute(text("ALTER TABLE email_tokens DROP COLUMN IF EXISTS token;"))
+        conn.execute(text("ALTER TABLE email_tokens ALTER COLUMN token_hash SET NOT NULL;"))
+        conn.execute(
+            text(
+                """
+                DO $$ BEGIN
+                BEGIN
+                    ALTER TABLE email_tokens ADD COLUMN used_at TIMESTAMPTZ NULL;
+                EXCEPTION WHEN duplicate_column THEN
+                    -- ignore
+                END;
+                END $$;
+                """
+            )
+        )


### PR DESCRIPTION
## Summary
- Persist only hashed tokens and add startup migration to drop any plaintext column
- Introduce utilities for generating and hashing tokens and update signup/reset flows to store token hashes
- Track token usage time and add helper to purge expired tokens

## Testing
- `pytest`
- `python -m py_compile app.py db.py models.py`


------
https://chatgpt.com/codex/tasks/task_e_68ac708410f483328dec4f2767759728