### PR TITLE
Add CSRF header for phase update and remove inline back handlers

### DIFF
--- a/web/init.js
+++ b/web/init.js
@@ -11,6 +11,10 @@ document.addEventListener('DOMContentLoaded', () => {
     chip.addEventListener('change', e => window.savePhase(String(e.target.value || '').toLowerCase()));
   }
 
+  document.querySelectorAll('.back-btn').forEach(btn => {
+    btn.addEventListener('click', () => history.back());
+  });
+
   fetch('/me', {credentials: 'include'})
     .then(r => {
       if (r.status === 401) return null;

--- a/web/phase.js
+++ b/web/phase.js
@@ -1,9 +1,22 @@
+function getCsrf() {
+  if (window.readCookie) return window.readCookie('csrf_token');
+  return document.cookie.split('; ').reduce((acc, part) => {
+    const [k, v] = part.split('=');
+    if (k === 'csrf_token') acc = decodeURIComponent(v || '');
+    return acc;
+  }, '');
+}
+
 window.savePhase = async function(phase) {
   const val = String(phase || '').toLowerCase();
+  const csrf = getCsrf();
   const resp = await fetch('/phase', {
     method: 'POST',
     credentials: 'include',
-    headers: { 'Content-Type': 'application/json' },
+    headers: {
+      'Content-Type': 'application/json',
+      'X-CSRF-Token': csrf
+    },
     body: JSON.stringify({ phase: val })
   });
   if (!resp.ok) return;

--- a/web/signin.html
+++ b/web/signin.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css?v=1">
 </head>
 <body>
-  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
+  <button class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Sign In</h1>
     <form id="signin-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">

--- a/web/signup.html
+++ b/web/signup.html
@@ -7,7 +7,7 @@
   <link rel="stylesheet" href="/style.css?v=1">
 </head>
 <body>
-  <button onclick="history.back()" class="btn ghost back-btn">Back</button>
+  <button class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Sign Up</h1>
     <form id="signup-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">


### PR DESCRIPTION
## Summary
- add CSRF token helper and send X-CSRF-Token header for POST /phase
- bind back buttons in JS and remove inline onclick handlers from auth pages

## Testing
- `node --check web/phase.js web/init.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68aca0b1d9148332a11ccf81efde597f