### PR TITLE
Handle bad rate limit storage URI by falling back to memory

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,9 +58,15 @@ if ENV == "production":
     app.config.update(SESSION_COOKIE_SECURE=True)
 
 storage_uri = os.getenv("RATELIMIT_STORAGE_URI", "memory://")
-limiter = Limiter(
-    get_remote_address, app=app, storage_uri=storage_uri, default_limits=[]
-)
+try:
+    limiter = Limiter(get_remote_address, app=app, storage_uri=storage_uri)
+except Exception:
+    # Log warning and fall back to in-memory so deploy never fails
+    app.logger.warning(
+        "Limiter storage '%s' unavailable; falling back to memory://",
+        storage_uri,
+    )
+    limiter = Limiter(get_remote_address, app=app, storage_uri="memory://")
 
 
 BCRYPT_PREFIX_RE = re.compile(r"^\$2[aby]?\$")


### PR DESCRIPTION
## Summary
- Harden Flask rate limiter initialization by gracefully falling back to `memory://` storage if the configured backend is unavailable

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aca48233c883329028afead6c86e4f