### PR TITLE
Restore navigation and post-auth flow

### DIFF
--- a/web/auth.js
+++ b/web/auth.js
@@ -33,57 +33,54 @@ document.addEventListener('DOMContentLoaded', () => {
       .catch(() => {});
   }
 
-  const signupForm = document.getElementById('signup-form');
-  if (signupForm) {
-    signupForm.addEventListener('submit', async (e) => {
+  const signUpForm = document.getElementById('signup-form');
+  if (signUpForm) {
+    signUpForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const email = document.getElementById('signup-email').value.trim();
-      const password = document.getElementById('signup-password').value;
+      const email = signUpForm.querySelector('input[name="email"]')?.value || '';
+      const password = signUpForm.querySelector('input[name="password"]')?.value || '';
       const msg = document.getElementById('signup-msg');
-      if (!email || !password) {
-        msg.textContent = 'Please fill in all fields.';
-        return;
-      }
-      msg.textContent = 'Creating...';
       try {
-        const res = await fetch('/signup', {
+        const resp = await fetch('/signup', {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password })
         });
-        const data = await res.json();
-        msg.textContent = res.ok ? (data.message || 'Account created. Please verify via email.') : (data.error || 'Sign-up failed.');
-      } catch (err) {
-        msg.textContent = 'Sign-up failed.';
+        if (resp.ok) {
+          window.location.href = '/signin.html?registered=1';
+        } else {
+          const data = await resp.json().catch(() => ({}));
+          if (msg) msg.textContent = data.error || 'Sign-up failed.';
+        }
+      } catch (_) {
+        if (msg) msg.textContent = 'Sign-up failed.';
       }
     });
   }
 
-  const signinForm = document.getElementById('signin-form');
-  if (signinForm) {
-    signinForm.addEventListener('submit', async (e) => {
+  const signInForm = document.getElementById('signin-form');
+  if (signInForm) {
+    signInForm.addEventListener('submit', async (e) => {
       e.preventDefault();
-      const email = document.getElementById('signin-email').value.trim();
-      const password = document.getElementById('signin-password').value;
+      const email = signInForm.querySelector('input[name="email"]')?.value || '';
+      const password = signInForm.querySelector('input[name="password"]')?.value || '';
       const msg = document.getElementById('signin-msg');
-      msg.textContent = 'Signing in...';
       try {
-        const res = await fetch('/login', {
+        const resp = await fetch('/login', {
           method: 'POST',
           credentials: 'include',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ email, password })
         });
-        const data = await res.json();
-        if (res.ok && data.ok) {
-          msg.textContent = 'Sign-in successful!';
-          setTimeout(() => { location.reload(); }, 800);
+        if (resp.ok) {
+          window.location.href = '/';
         } else {
-          msg.textContent = data.error || 'Invalid credentials.';
+          const data = await resp.json().catch(() => ({}));
+          if (msg) msg.textContent = data.error || 'Invalid credentials.';
         }
-      } catch (err) {
-        msg.textContent = 'Sign-in failed.';
+      } catch (_) {
+        if (msg) msg.textContent = 'Sign-in failed.';
       }
     });
   }

--- a/web/index.html
+++ b/web/index.html
@@ -28,9 +28,9 @@
         <h1>We got you! Step by step you'll get there.</h1>
         <p class="muted">I’ll ask one or two things, then show just your next step.</p>
         <div class="choices tiles">
-          <button class="tile" data-choice="lost" style="--bg:url('/img/home1b.jpg');"><span class="label">I just lost my job</span></button>
-          <button class="tile" data-choice="explore" style="--bg:url('/img/home3.jpg');"><span class="label">I’m exploring a change</span></button>
-          <button class="tile" data-choice="stuck" style="--bg:url('/img/home4b.jpg');"><span class="label">I’m stuck in my job</span></button>
+          <button id="tile-plan" class="tile" data-choice="lost" data-href="/index.html#plan" style="--bg:url('/img/home1b.jpg');"><span class="label">I just lost my job</span></button>
+          <button id="tile-jobs" class="tile" data-choice="explore" data-href="/index.html#jobs" style="--bg:url('/img/home3.jpg');"><span class="label">I’m exploring a change</span></button>
+          <button id="tile-tools" class="tile" data-choice="stuck" data-href="/index.html#tools" style="--bg:url('/img/home4b.jpg');"><span class="label">I’m stuck in my job</span></button>
         </div>
         <button id="skip-intake" class="btn">Skip — just give me a plan</button>
       </div>

--- a/web/init.js
+++ b/web/init.js
@@ -11,8 +11,16 @@ document.addEventListener('DOMContentLoaded', () => {
     chip.addEventListener('change', e => window.savePhase(String(e.target.value || '').toLowerCase()));
   }
 
+  document.querySelectorAll('.tile[id^="tile-"], .tile[data-href]').forEach(el => {
+    const href = el.getAttribute('data-href');
+    if (href) {
+      el.style.cursor = 'pointer';
+      el.addEventListener('click', () => { window.location.href = href; });
+    }
+  });
+
   document.querySelectorAll('.back-btn').forEach(btn => {
-    btn.addEventListener('click', () => history.back());
+    btn.addEventListener('click', (e) => { e.preventDefault(); history.back(); });
   });
 
   fetch('/me', {credentials: 'include'})
@@ -35,4 +43,12 @@ document.addEventListener('DOMContentLoaded', () => {
       });
     })
     .catch(() => {});
+
+  const pathname = window.location.pathname;
+  if (pathname.endsWith('/signin.html') || pathname.endsWith('/signup.html')) {
+    fetch('/me', { credentials: 'include' })
+      .then(r => r.ok ? r.json() : null)
+      .then(data => { if (data && data.user) window.location.href = '/'; })
+      .catch(() => {});
+  }
 });

--- a/web/signin.html
+++ b/web/signin.html
@@ -7,19 +7,19 @@
   <link rel="stylesheet" href="/style.css?v=1">
 </head>
 <body>
-  <button class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Sign In</h1>
     <form id="signin-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">
       <div class="form-row">
         <label for="signin-email" class="label">Email</label>
-        <input id="signin-email" class="input" type="email" autocomplete="off" required>
+        <input id="signin-email" name="email" class="input" type="email" autocomplete="off" required>
       </div>
       <div class="form-row">
         <label for="signin-password" class="label">Password</label>
-        <input id="signin-password" class="input" type="password" required>
+        <input id="signin-password" name="password" class="input" type="password" required>
       </div>
       <button class="btn primary" type="submit">Sign In</button>
+      <button type="button" class="btn ghost back-btn">Back</button>
       <p id="signin-msg" class="muted"></p>
     </form>
     <p style="text-align:center; margin-top:1rem;"><a id="forgot-password" href="#">Forgot password?</a></p>

--- a/web/signup.html
+++ b/web/signup.html
@@ -7,19 +7,19 @@
   <link rel="stylesheet" href="/style.css?v=1">
 </head>
 <body>
-  <button class="btn ghost back-btn">Back</button>
   <div class="wrap">
     <h1>Sign Up</h1>
     <form id="signup-form" class="card panel" style="display:grid; gap:.8rem; max-width:400px; margin:0 auto;">
       <div class="form-row">
         <label for="signup-email" class="label">Email</label>
-        <input id="signup-email" class="input" type="email" autocomplete="off" required>
+        <input id="signup-email" name="email" class="input" type="email" autocomplete="off" required>
       </div>
       <div class="form-row">
         <label for="signup-password" class="label">Password</label>
-        <input id="signup-password" class="input" type="password" required>
+        <input id="signup-password" name="password" class="input" type="password" required>
       </div>
       <button class="btn primary" type="submit">Create Account</button>
+      <button type="button" class="btn ghost back-btn">Back</button>
       <p id="signup-msg" class="muted"></p>
     </form>
   </div>


### PR DESCRIPTION
## Summary
- Wire up welcome screen tiles for navigation without inline handlers
- Enable back buttons and redirect after sign-in/sign-up
- Redirect logged-in users away from auth pages

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68acad668e548332a625028a68adabc3