### PR TITLE
Restore navigation with anchor links and JS fallback

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -13,7 +13,7 @@
     <header>
       <a class="logo" href="#"><span class="mark">N</span> NextChapter</a>
       <div style="display:flex; gap:.5rem; align-items:center;">
-        <button id="open-library" class="btn ghost" aria-expanded="false">Tools</button>
+        <a id="open-library" class="btn ghost" href="/index.html#tools">Tools</a>
         <button id="reset" class="btn ghost" title="Clear saved state">Reset</button>
         <div id="auth-links" style="display:flex; gap:.5rem;">
           <a href="signup.html" class="btn ghost">Sign Up</a>
@@ -28,9 +28,9 @@
         <h1>We got you! Step by step you'll get there.</h1>
         <p class="muted">I’ll ask one or two things, then show just your next step.</p>
         <div class="choices tiles">
-          <button id="tile-plan" class="tile" data-choice="lost" data-href="/index.html#plan" style="--bg:url('/img/home1b.jpg');"><span class="label">I just lost my job</span></button>
-          <button id="tile-jobs" class="tile" data-choice="explore" data-href="/index.html#jobs" style="--bg:url('/img/home3.jpg');"><span class="label">I’m exploring a change</span></button>
-          <button id="tile-tools" class="tile" data-choice="stuck" data-href="/index.html#tools" style="--bg:url('/img/home4b.jpg');"><span class="label">I’m stuck in my job</span></button>
+          <a id="tile-plan" class="tile" data-choice="lost" href="/index.html#plan" style="--bg:url('/img/home1b.jpg');"><span class="label">I just lost my job</span></a>
+          <a id="tile-jobs" class="tile" data-choice="explore" href="/index.html#jobs" style="--bg:url('/img/home3.jpg');"><span class="label">I’m exploring a change</span></a>
+          <a id="tile-tools" class="tile" data-choice="stuck" href="/index.html#tools" style="--bg:url('/img/home4b.jpg');"><span class="label">I’m stuck in my job</span></a>
         </div>
         <button id="skip-intake" class="btn">Skip — just give me a plan</button>
       </div>

--- a/web/init.js
+++ b/web/init.js
@@ -11,12 +11,15 @@ document.addEventListener('DOMContentLoaded', () => {
     chip.addEventListener('change', e => window.savePhase(String(e.target.value || '').toLowerCase()));
   }
 
-  document.querySelectorAll('.tile[id^="tile-"], .tile[data-href]').forEach(el => {
+  document.querySelectorAll('[data-href]').forEach(el => {
     const href = el.getAttribute('data-href');
-    if (href) {
-      el.style.cursor = 'pointer';
-      el.addEventListener('click', () => { window.location.href = href; });
-    }
+    if (!href) return;
+    el.style.cursor = 'pointer';
+    el.setAttribute('tabindex', '0');
+    el.addEventListener('click', () => { window.location.href = href; });
+    el.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter' || e.key === ' ') { e.preventDefault(); el.click(); }
+    });
   });
 
   document.querySelectorAll('.back-btn').forEach(btn => {

--- a/web/signin.html
+++ b/web/signin.html
@@ -19,7 +19,7 @@
         <input id="signin-password" name="password" class="input" type="password" required>
       </div>
       <button class="btn primary" type="submit">Sign In</button>
-      <button type="button" class="btn ghost back-btn">Back</button>
+      <a class="btn ghost back-btn" href="javascript:void(0)">Back</a>
       <p id="signin-msg" class="muted"></p>
     </form>
     <p style="text-align:center; margin-top:1rem;"><a id="forgot-password" href="#">Forgot password?</a></p>

--- a/web/signup.html
+++ b/web/signup.html
@@ -19,7 +19,7 @@
         <input id="signup-password" name="password" class="input" type="password" required>
       </div>
       <button class="btn primary" type="submit">Create Account</button>
-      <button type="button" class="btn ghost back-btn">Back</button>
+      <a class="btn ghost back-btn" href="javascript:void(0)">Back</a>
       <p id="signup-msg" class="muted"></p>
     </form>
   </div>

--- a/web/style.css
+++ b/web/style.css
@@ -54,7 +54,7 @@
     .btn:focus-visible{outline:none; box-shadow:0 0 0 3px var(--focus), var(--shadow)}
     .btn.primary{background:#fff; color:var(--accent); border-color:var(--accent)}
     .btn.ghost{background:#fff; color:var(--accent); border-color:var(--accent); opacity:1}
-    a.btn{text-decoration:none}
+    a.btn{display:inline-block; text-decoration:none}
 
     /* Coach panel */
     .coach-fab{position:fixed; right:20px; bottom:20px; z-index:90;} /* below coach panel */


### PR DESCRIPTION
## Summary
- Convert welcome tiles and top Tools control into proper `<a>` links
- Style anchor buttons and add data-href fallback with keyboard support
- Replace inline Back buttons with links and bind history navigation

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `node --check web/init.js web/auth.js`


------
https://chatgpt.com/codex/tasks/task_e_68acb17f0b9883329de94c0389eec976